### PR TITLE
Create a thumbnail directory in the keynote file current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,10 @@ A git clean filter to help work with Keynote files in git.
 
 ### How to use
 
-Add your file to the `.gitattributes` add the file you want tracked like in the following example:
+Add the Keynote extension to the `.gitattributes` like in the following example:
 
 ```
 *.key    filter=thumbscrew
-Example  filter=thumbscrew
 ```
 
 Use `git add` and `git commit` the way you would regularly do this.

--- a/thumbscrew-clean
+++ b/thumbscrew-clean
@@ -5,7 +5,6 @@ NAME=${1}
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
 GTL=`git rev-parse --show-toplevel`
-[ -d "${GTL}/keynotes" ] || mkdir "${GTL}/keynotes"
 
 /usr/bin/osascript ${DIR}/thumbscrew.scpt ${GTL} ${NAME} 2>/dev/null
 cat -

--- a/thumbscrew.scpt
+++ b/thumbscrew.scpt
@@ -16,6 +16,7 @@ on run argv
   set documentName to item 2 of argv
   set documentFullName to repoPath & "/" & documentName
 
+  set keynoteFile to (POSIX file documentFullName) as alias
   set documentPath to posix file (POSIX path of (do shell script "dirname " & quoted form of documentFullName)) as alias
 
   tell application "Finder"
@@ -28,7 +29,7 @@ on run argv
 
   tell application "Keynote" to run
   tell application "Keynote"
-    open documentFullName
+    open keynoteFile
 
     if playing is true then stop the front document
 

--- a/thumbscrew.scpt
+++ b/thumbscrew.scpt
@@ -1,35 +1,34 @@
 -- thumbscrew.scpt
--- usage: thumbscript.scpt <path_to_root_dir> <path_to_keynotePresentation>
+-- usage: thumbscript.scpt <keynotePresentation>
 --
 -- Will create scaled thumbnails of length `thumbSize` in the directory
--- <path_to_root_dir>/<thumbnailDir>/<presentation>
+-- <path_to_keynotePresentation>/<thumbnailDir>
 property thumbSize : 480
-property thumbnailDir: "keynotes"
+property thumbnailDir: "thumbnail"
+
 
 on getImages(f)
   tell application "Finder" to return (files of folder f) as alias list
 end getImages
 
 on run argv
-  set gitRoot to item 1 of argv
-  set tmpFile to item 2 of argv
+  set repoPath to item 1 of argv
   set documentName to item 2 of argv
-  if documentName ends with ".key" then set documentName to text 1 thru -5 of documentName
+  set documentFullName to repoPath & "/" & documentName
 
-  set gitRoot to posix file (POSIX path of (gitRoot as text) & "/" & thumbnailDir) as alias
-  set tmpFile to (POSIX file tmpFile) as alias
+  set documentPath to posix file (POSIX path of (do shell script "dirname " & quoted form of documentFullName)) as alias
 
   tell application "Finder"
-    if not (exists folder documentName of folder gitRoot)
-      make new folder at gitRoot with properties {name:documentName}
+    if not (exists folder thumbnailDir of folder documentPath)
+      make new folder at folder documentPath with properties {name:thumbnailDir}
     end if
-    set the targetFolder to folder documentName of folder gitRoot
+    set the targetFolder to folder thumbnailDir of folder documentPath
     set the targetFolderHFSPath to targetFolder as string
   end tell
 
   tell application "Keynote" to run
   tell application "Keynote"
-    open tmpFile
+    open documentFullName
 
     if playing is true then stop the front document
 
@@ -51,4 +50,5 @@ on run argv
 
     close front document without saving
   end tell
+
 end run


### PR DESCRIPTION
Instead of going back to the root of the repo and creating a directory with a weird name (`folder1:folder2:filename`), this version just create a `thumbnail` folder in the keynote file's current directory. 